### PR TITLE
Fix typo in Discord link generation

### DIFF
--- a/components/slides/Socials.js
+++ b/components/slides/Socials.js
@@ -20,7 +20,7 @@ export default function Socials({ back }) {
     if (document.getElementById("discord").value != "") {
       socials =
         socials +
-        `[![Discord](https://img.shields.io/badge/Discord-%237289DA.svg?logo=discord&logoColor=white)](htttps://discord.gg/${
+        `[![Discord](https://img.shields.io/badge/Discord-%237289DA.svg?logo=discord&logoColor=white)](https://discord.gg/${
           document.getElementById("discord").value
         }) `;
     }


### PR DESCRIPTION
`https` was typed as `htttps`