### PR TITLE
Fix in Youtube link generation.

### DIFF
--- a/components/slides/Socials.js
+++ b/components/slides/Socials.js
@@ -104,7 +104,7 @@ export default function Socials({ back }) {
     if (document.getElementById("youtube").value != "") {
       socials =
         socials +
-        `[![YouTube](https://img.shields.io/badge/YouTube-%23FF0000.svg?logo=YouTube&logoColor=white)](https://youtube.com/c/${
+        `[![YouTube](https://img.shields.io/badge/YouTube-%23FF0000.svg?logo=YouTube&logoColor=white)](https://youtube.com/@${
           document.getElementById("youtube").value
         }) `;
     }


### PR DESCRIPTION
Change in socials.js youtube link generation.

Changed the old "/c/" method to the new "/@" to remove the "404 page not found" error 
as I created a link to my youtube channel by entering my username but on clicking the "youtube" button it was showing an error so here is my proposal to change the old link generation method to the new one.

Ex: If the user enters the username "ishaankatara" on the website, according to your code it will generate this link "https://youtube.com/c/ishaankatara" but it will not work it will not be accepted by youtube and throw a 404 error. So instead of this, it should generate this link to be accepted by youtube "https://youtube.com/@ishaankatara"

So instead of "using https://youtube.com/c/" use "https://youtube.com/@"

![Screenshot (72)](https://user-images.githubusercontent.com/108490584/209481536-d5da5f18-a51e-41dd-adc8-a217baf29702.png)
![Screenshot (73)](https://user-images.githubusercontent.com/108490584/209481538-532bed21-bb42-4170-840f-09e6fc681ae0.png)
