### PR TITLE
fix: update tech.js for csharp logo to appear

### DIFF
--- a/data/tech.js
+++ b/data/tech.js
@@ -10,7 +10,7 @@ export const data = {
     },
     {
       label: "C#",
-      url: "![C#](https://img.shields.io/badge/c%23-%23239120.svg?style=for-the-badge&logo=c-sharp&logoColor=white)",
+      url: "![C#](https://img.shields.io/badge/c%23-%23239120.svg?style=for-the-badge&logo=csharp&logoColor=white)",
     },
     {
       label: "C++",


### PR DESCRIPTION
C# logo is spelled csharp not c-sharp