### PR TITLE
fix(preview): prevent raw HTML rendering in generated README preview

### DIFF
--- a/components/slides/Preview.js
+++ b/components/slides/Preview.js
@@ -10,7 +10,7 @@ export default function Preview({ back }) {
   const [downloadAlertVisible, setDownloadAlertVisible] = useState(false);
   const gprmStore = useGPRMStore();
   var md = require("markdown-it")({
-    html: true,
+    html: false,
     linkify: true,
     typographer: true,
     breaks: true,
@@ -35,8 +35,9 @@ export default function Preview({ back }) {
       // Checking if elements exists
       if (links.length > 0) {
         links.forEach((link) => {
-          // adding attribute target
+          // adding secure link attributes
           link.setAttribute("target", "_blank");
+          link.setAttribute("rel", "noopener noreferrer nofollow");
         });
       }
     }, 300);


### PR DESCRIPTION
## Summary
This PR hardens preview rendering in the Preview component by:

- setting markdown-it option `html: false` (instead of `html: true`)
- adding `rel="noopener noreferrer nofollow"` on rendered links opened with `target="_blank"`

## Why
The preview renders user-generated markdown via `innerHTML`. Allowing raw HTML in markdown can expose users to script/style injection in preview context. Disabling raw HTML keeps markdown rendering but blocks direct HTML injection.

The link `rel` addition prevents reverse-tabnabbing and improves outbound link safety.

## Scope
Small, isolated security-focused change.
